### PR TITLE
Update q-ajax-filter.php

### DIFF
--- a/q-ajax-filter.php
+++ b/q-ajax-filter.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'Q_AJAX_Filter' ) )
             
             global $post;
             
-            if ( is_page() && $post && has_shortcode( $post->post_content, 'ajaxFilter' ) ){
+            if ( is_page() && $post && do_shortcode( 'ajaxFilter') ){
                 
                 // build an empty array, if not present ##
                 if ( ! is_array( $classes ) ) { $classes = array(); }
@@ -233,7 +233,7 @@ if ( ! class_exists( 'Q_AJAX_Filter' ) )
             
             global $post;
             
-            if ( isset( $post ) && has_shortcode( $post->post_content, 'ajaxFilter') ){
+            if ( isset( $post ) && do_shortcode( 'ajaxFilter') ){
                 
                 // get the theme path & URL ##
                 $theme_path = get_stylesheet_directory();

--- a/q-ajax-filter.php
+++ b/q-ajax-filter.php
@@ -4,7 +4,7 @@
  * Plugin Name: Search & Filter via AJAX
  * Plugin URI: http://qstudio.us/plugins/
  * Description: Filter posts by taxonomies or text search using AJAX to load results
- * Version: 1.7.2
+ * Version: 1.7.3
  * Author: Q Studio
  * Author URI: http://qstudio.us
  * License: GPL2
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Q_AJAX_Filter' ) )
     }
     
     // plugin version
-    define( 'Q_AJAX_FILTER_VERSION', '1.7.2' ); // version ##
+    define( 'Q_AJAX_FILTER_VERSION', '1.7.3' ); // version ##
     
     // instatiate plugin via WP hook - not too early, not too late ##
     add_action( 'init', array ( 'Q_AJAX_Filter', 'get_instance' ), 0 );
@@ -127,7 +127,7 @@ if ( ! class_exists( 'Q_AJAX_Filter' ) )
             
             global $post;
             
-            if ( is_page() && $post && do_shortcode( 'ajaxFilter') ){
+            if ( is_page() && $post && has_shortcode( $post->post_content, 'ajaxFilter' ) ){
                 
                 // build an empty array, if not present ##
                 if ( ! is_array( $classes ) ) { $classes = array(); }
@@ -219,21 +219,16 @@ if ( ! class_exists( 'Q_AJAX_Filter' ) )
 ?>
                 </section>
             </div>
-<?php
-    
-        }
 
-        
-        /**
+<?php
+             /**
          *
          * method to include all required scripts
          * @since 1.5
          */
-        function wp_enqueue_scripts(){
-            
             global $post;
             
-            if ( isset( $post ) && do_shortcode( 'ajaxFilter') ){
+            if ( isset( $post ) ){
                 
                 // get the theme path & URL ##
                 $theme_path = get_stylesheet_directory();


### PR DESCRIPTION
When adding a search filter by using do_shortcode, the 'body_class' and 'wp_enqueue_scripts' functions do not execute. This is because the "has_shortcode" condition can only detect shortcodes that have been added using the "add_shortcode" method.  The same goes for when one uses the  'ajax_filter(array($args))' function directly. Sothe wp_enqueue_scripts function has been placed directly at the end of the ajax_filter function so the scripts necessary to make the plugin work will be added no matter what method is used.
